### PR TITLE
chore: remove repository metadata block in package.json

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -14,8 +14,4 @@
   "devDependencies": {
     "grunt": "^0.4.5"
   },
-  "repository" : {
-    "type" : "git",
-    "url" : "http://github.com/dlorenc/dockerize.git"
-  }
-}
+ 


### PR DESCRIPTION
Clean up outdated git repository references from packages metadata.